### PR TITLE
AboutMe 페이지 추가 및 CSS 스타일 적용, 라우터 설정 변경

### DIFF
--- a/src/pages/about/AboutMe.jsx
+++ b/src/pages/about/AboutMe.jsx
@@ -1,5 +1,56 @@
+import React from 'react'
+import './styles/AboutMe.css' // 사용자 정의 CSS 파일 import
+
 const AboutMe = () => {
-  return
+  return (
+    <div className="gamja-flower-regular flex flex-col items-center min-h-screen bg-rose-50 p-6 pt-14">
+      <div className="flex flex-col space-y-8 border-">
+        <div className="flex items-center space-x-8">
+          <div className="polaroid relative">
+            <img src="src/assets/images/프로필.jpg" alt="프로필 사진" className="polaroid-image" />
+            <div className="absolute -top-8 -left-14">
+              <img
+                className="w-24 h-24 object-cover"
+                src="https://media-public.canva.com/23PTk/MAFQIE23PTk/1/t.png"
+                alt="aesthetic washi tape"
+              />
+            </div>
+          </div>
+          <div className="intro-text text-right">
+            <h1 className="text-5xl font-bold text-gray-700 py-8">안녕하세요 ♪(´▽｀)</h1>
+            <p className="text-7xl text-gray-700">저는 방혜진</p>
+            <p className="text-7xl text-gray-700">입니다</p>
+            <p className="text-4xl text-rose-400 py-8">2001/08/13</p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-8">
+          <div className="intro-text-left text-left">
+            <h1 className="text-5xl font-bold text-gray-700 py-8">About Me</h1>
+            <p className="text-4xl text-rose-400">
+              정보통신공학과를 졸업한 후 개발과는 다른 분야에서 근무하던 중, 개발자분들의 협업 하는 과정에서 사용자
+              경험을 개선하고, 직관적인 인터페이스를 설계하는 모습을 보고 웹 개발에 관심을 가지게 되었습니다. 현재는
+              프론트엔드 개발자로서의 목표를 세우고, 이를 달성하기 위해 열심히 공부하고 있습니다. (๑•̀ㅂ•́)و✧
+            </p>
+          </div>
+          <div className="polaroid-right">
+            <img src="src/assets/images/내소개사진1.jpg" alt="내소개사진" className="polaroid-image" />
+          </div>
+        </div>
+        <div className="flex items-center space-x-8 py-8">
+          <div className="polaroid-left">
+            <img src="src/assets/images/영종도여행_썸네일.jpg" alt="취미생활사진" className="polaroid-image" />
+          </div>
+          <div className="intro-text-right text-right">
+            <h1 className="text-5xl font-bold text-gray-700 py-8">Hobby</h1>
+            <p className="text-4xl text-rose-400">
+              친구들이랑 여행다니는 걸 제일 좋아합니다. 개인적으로 제일 좋았던 여행지는 부산이에요. 아직 해외여행은 가본
+              적 없지만 시간적 여유가 생기면 해외여행도 다녀보고 싶어요!
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default AboutMe

--- a/src/pages/about/router.jsx
+++ b/src/pages/about/router.jsx
@@ -1,6 +1,4 @@
-import React, { lazy } from 'react'
-
-const About = lazy(() => import('@pages/about/AboutMe.jsx'))
+import About from '@pages/about/AboutMe.jsx'
 
 const router = [
   {

--- a/src/pages/about/styles/AboutMe.css
+++ b/src/pages/about/styles/AboutMe.css
@@ -1,0 +1,91 @@
+/* AboutMe.css */
+
+@import url('https://fonts.googleapis.com/css2?family=Gamja+Flower&display=swap');
+
+.gamja-flower-regular {
+  font-family: 'Gamja Flower', sans-serif;
+}
+
+.polaroid {
+  background: white;
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  position: relative;
+  display: inline-block;
+  transform: rotate(-3deg); /* 기울임 효과 */
+  width: 400px; /* 폴라로이드의 너비 */
+  height: 540px; /* 폴라로이드의 높이 */
+  margin-bottom: 1rem; /* 이미지 하단 여백 */
+}
+
+.polaroid-right {
+  background: white;
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  position: relative;
+  display: inline-block;
+  transform: rotate(3deg); /* 기울임 효과 */
+  width: 340px; /* 폴라로이드의 너비 */
+  height: 480px; /* 폴라로이드의 높이 */
+  margin-bottom: 1rem; /* 이미지 하단 여백 */
+}
+
+.polaroid-left {
+  background: white;
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  position: relative;
+  display: inline-block;
+  transform: rotate(-2deg); /* 기울임 효과 */
+  width: 600px; /* 폴라로이드의 너비 */
+  height: 540px; /* 폴라로이드의 높이 */
+  margin-bottom: 1rem; /* 이미지 하단 여백 */
+}
+
+.polaroid img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.polaroid::after {
+  content: '';
+  display: block;
+  height: 70px; /* 하단 여백의 높이 */
+  background: white;
+  border-top: 1px solid #ddd;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.polaroid-left::after {
+  content: '';
+  display: block;
+  height: 80px; /* 하단 여백의 높이 */
+  background: white;
+  border-top: 1px solid #ddd;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.intro-text {
+  max-width: 600px;
+  padding-left: 6rem; /* 이미지와 텍스트 사이의 여백 */
+}
+
+.intro-text-left {
+  max-width: 600px;
+  padding-right: 6rem; /* 이미지와 텍스트 사이의 여백 */
+}
+
+.intro-text-right {
+  max-width: 400px;
+  padding-right: 6rem; /* 이미지와 텍스트 사이의 여백 */
+}


### PR DESCRIPTION
1. **AboutMe 페이지 추가**
   - 새로운 `AboutMe` 컴포넌트를 추가.
   - 페이지에는 사용자 프로필과 소개, 취미 정보를 포함.
   - 관련 이미지와 텍스트를 포함하여 디자인을 개선.

2. **CSS 스타일 추가**
   - `AboutMe` 페이지를 위한 사용자 정의 CSS 파일을 추가.
   - 폴라로이드 스타일의 이미지 레이아웃과 텍스트 스타일을 설정.
   - 스타일링에는 폰트 설정, 이미지 여백, 기울임 효과 등이 포함.

3. **라우터 설정 변경**
   - `react.lazy`를 사용한 동적 import 방식을 삭제하고, `AboutMe` 컴포넌트를 직접 import 하도록 변경.
   
<br />

AboutMe 페이지가 추가되었으며, 페이지의 스타일과 라우팅 방식이 개선되었다.
