### PR TITLE
라우터 설정 변경: 동적 import를 직접 import로 수정

### DIFF
--- a/src/router.jsx
+++ b/src/router.jsx
@@ -10,14 +10,14 @@ import NotFound from '@common/components/NotFound.jsx'
 import home from '@pages/home/router.jsx'
 import about from '@pages/about/router.jsx'
 import movie from '@pages/movies/router.jsx'
-import travel from '@pages/travel/router.jsx'
 import food from '@pages/food/router.jsx'
+import travel from '@pages/travel/router.jsx'
 import HomeDetail from '@pages/home/router.jsx'
+import Project from '@pages/projects/Projects.jsx'
+import Contact from '@pages/contact/Contact.jsx'
+import Detail from '@pages/detail/Detail.jsx'
 
-const Project = lazy(() => import('@pages/projects/Projects.jsx'))
-const Contact = lazy(() => import('@pages/contact/Contact.jsx'))
 const Test = lazy(() => import('@pages/test/Test.jsx'))
-const Detail = lazy(() => import('@pages/detail/Detail.jsx'))
 
 // 라우터 설정
 const router = createBrowserRouter([
@@ -30,7 +30,7 @@ const router = createBrowserRouter([
         </Suspense>
       </Layout>
     ),
-    children: [...home, ...about, ...movie, ...travel, ...food, ...HomeDetail],
+    children: [...home, ...about, ...movie, ...food, ...HomeDetail, ...travel],
     errorElement: <NotFound />
   },
   {
@@ -45,7 +45,11 @@ const router = createBrowserRouter([
   },
   {
     path: '/test',
-    element: <Test />,
+    element: (
+      <Suspense>
+        <Test />
+      </Suspense>
+    ),
     errorElement: <NotFound />
   },
   {


### PR DESCRIPTION
이 PR은 전체 `router.jsx` 파일에 대한 수정 사항을 포함한다:

1. **동적 import 제거**
   - `react.lazy`를 사용하여 동적으로 import하던 `Project`, `Contact`, `Detail` 페이지를 직접 import 방식으로 변경.

2. **변경 이유**
   - 동적 import의 필요성 감소.